### PR TITLE
Add filetype jinja in backend

### DIFF
--- a/custom_components/config_editor/__init__.py
+++ b/custom_components/config_editor/__init__.py
@@ -29,7 +29,7 @@ async def async_setup(hass, config):
 async def websocket_create(hass, connection, msg):
     action = msg["action"]
     ext = msg["ext"]
-    if ext not in ["yaml","py","json","conf","js","txt","log","css","all"]:
+    if ext not in ["yaml","py","json","conf","js","txt","log","css","jinja","all"]:
         ext = "yaml"
 
     def extok(e):


### PR DESCRIPTION
Hi, I would like to propose this change. Files with `.jinja` extension are useful for: https://www.home-assistant.io/docs/configuration/templating/#reusing-templates